### PR TITLE
Update SimpleBluez to 0.8.1

### DIFF
--- a/src/bleinterfacebluez.cpp
+++ b/src/bleinterfacebluez.cpp
@@ -86,7 +86,7 @@ void BLEInterfaceBluez::addDevices(std::vector<std::shared_ptr<SimpleBluez::Devi
 void BLEInterfaceBluez::readCharacteristicByService(const std::shared_ptr<SimpleBluez::Service> &service )
 {
     for (auto charac : service->characteristics()) {
-        SimpleBluez::ByteArray value = charac->read();
+        std::string value = charac->read();
         auto battery_value = hex2dec(QString::fromStdString(value.c_str()).toUtf8().toHex().toStdString());
         qDebug() << "Characteristic uuid: " << charac->uuid();
         qDebug() << "Characteristic contents: " << battery_value;

--- a/src/thirdparty/simplebluez/Device.h
+++ b/src/thirdparty/simplebluez/Device.h
@@ -29,8 +29,8 @@ class Device : public SimpleDBus::Proxy {
     int16_t rssi();
     int16_t tx_power();
 
-    std::map<uint16_t, std::vector<uint8_t>> manufacturer_data();
-    std::map<std::string, std::vector<uint8_t>> service_data();
+    std::map<uint16_t, ByteArray> manufacturer_data();
+    std::map<std::string, ByteArray> service_data();
 
     bool paired();
     bool connected();

--- a/src/thirdparty/simplebluez/Types.h
+++ b/src/thirdparty/simplebluez/Types.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <string>
+#include "external/kvn_bytearray.h"
 
 namespace SimpleBluez {
 
-typedef std::string ByteArray;
+using ByteArray = kvn::bytearray;
 
 }

--- a/src/thirdparty/simplebluez/external/kvn_bytearray.h
+++ b/src/thirdparty/simplebluez/external/kvn_bytearray.h
@@ -1,0 +1,200 @@
+#ifndef KVN_BYTEARRAY_H
+#define KVN_BYTEARRAY_H
+
+#include <cstdint>
+#include <cstring>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+#include <vector>
+
+namespace kvn {
+
+/**
+ * @class bytearray
+ * @brief A class to handle byte arrays and their conversion from/to hex strings.
+ */
+class bytearray {
+  public:
+    /**
+     * @brief Default constructor.
+     */
+    bytearray() = default;
+
+    /**
+     * @brief Constructs byte array from a vector of uint8_t.
+     * @param vec A vector of uint8_t.
+     */
+    bytearray(const std::vector<uint8_t>& vec) : data_(vec) {}
+
+    /**
+     * @brief Constructs byte array from a raw pointer and size.
+     * @param ptr A pointer to uint8_t data.
+     * @param size The size of the data.
+     */
+    bytearray(const uint8_t* ptr, size_t size) : data_(ptr, ptr + size) {}
+
+    /**
+     * @brief Constructs byte array from a std::string.
+     * @param byteArr A string containing byte data.
+     */
+    bytearray(const std::string& byteArr) : data_(byteArr.begin(), byteArr.end()) {}
+
+    /**
+     * @brief Constructs byte array from a C-style string and size.
+     * @param byteArr A C-style string.
+     * @param size The size of the string.
+     */
+    bytearray(const char* byteArr, size_t size) : bytearray(std::string(byteArr, size)) {}
+
+    /**
+     * @brief Constructs byte array from a C-style string.
+     * @param byteArr A C-style string.
+     */
+    bytearray(const char* byteArr) : bytearray(std::string(byteArr)) {}
+
+    /**
+     * @brief Creates a ByteArray from a hex string.
+     *
+     * Case is ignored and the string may have a '0x' hex prefix or not.
+     *
+     * @param hexStr A string containing hex data.
+     * @return A ByteArray object.
+     * @throws std::invalid_argument If the hex string contains non-hexadecimal characters.
+     * @throws std::length_error If the hex string length is not even.
+     */
+    static bytearray fromHex(const std::string& hexStr) {
+        std::string cleanString(hexStr);
+
+        // Check and skip the '0x' prefix if present
+        if (cleanString.size() >= 2 && cleanString.substr(0, 2) == "0x") {
+            cleanString = cleanString.substr(2);
+        }
+
+        size_t size = cleanString.size();
+        if (size % 2 != 0) {
+            throw std::length_error("Hex string length must be even.");
+        }
+
+        bytearray byteArray;
+        byteArray.data_.reserve(size / 2);
+
+        for (size_t i = 0; i < size; i += 2) {
+            uint8_t byte = static_cast<uint8_t>(std::stoi(cleanString.substr(i, 2), nullptr, 16));
+            byteArray.data_.push_back(byte);
+        }
+
+        return byteArray;
+    }
+
+    /**
+     * @overload
+     */
+    static bytearray fromHex(const char* byteArr) { return fromHex(std::string(byteArr)); }
+
+    /**
+     * @overload
+     */
+    static bytearray fromHex(const char* byteArr, size_t size) { return fromHex(std::string(byteArr, size)); }
+
+    /**
+     * @brief Converts the byte array to a lowercase hex string without '0x' prefix.
+     * @param spacing Whether to include spaces between bytes.
+     *
+     * @return A hex string representation of the byte array.
+     */
+    std::string toHex(bool spacing = false) const {
+        std::ostringstream oss;
+        for (auto byte : data_) {
+            oss << std::hex << std::setw(2) << std::setfill('0') << static_cast<int>(byte);
+            if (spacing) {
+                oss << " ";
+            }
+        }
+        return oss.str();
+    }
+
+    /**
+     * @brief Slices  the byte array from a specified start index to an end index.
+     *
+     * This method creates a new byte array containing bytes from the specified range.
+     * The start index is inclusive, while the end index is exclusive.
+     *
+     * @param start The starting index from which to begin slicing.
+     * @param end The ending index up to which to slice (exclusive).
+     * @return byte array A new byte array containing the sliced segment.
+     * @throws std::out_of_range If the start index is greater than the end index or if the end index is out of bounds.
+     */
+    bytearray slice(size_t start, size_t end) const {
+        if (start > end || end > data_.size()) {
+            throw std::out_of_range("Invalid slice range");
+        }
+        return bytearray(std::vector<uint8_t>(data_.begin() + start, data_.begin() + end));
+    }
+
+    /**
+     * @brief Slices the byte array from a specified start index to the end of the array.
+     *
+     * This method creates a new byte array containing all bytes from the specified start index to the end of the
+     * byte array.
+     *
+     * @param start The starting index from which to begin slicing.
+     * @return byte array A new byte array containing the sliced segment from the start index to the end.
+     * @throws std::out_of_range If the start index is out of the bounds of the byte array.
+     */
+    bytearray slice_from(size_t start) const { return slice(start, data_.size()); }
+
+    /**
+     * @brief Slices the byte array from the beginning to a specified end index.
+     *
+     * This method creates a new byte array containing all bytes from the beginning of the byte array to the specified
+     * end index.
+     *
+     * @param end The ending index up to which to slice (exclusive).
+     * @return byte array A new byte array containing the sliced segment from the beginning to the end index.
+     * @throws std::out_of_range If the end index is out of the bounds of the byte array.
+     */
+    bytearray slice_to(size_t end) const { return slice(0, end); }
+
+    /**
+     * @brief Overloaded stream insertion operator for byte array.
+     * @param os The output stream.
+     * @param byteArray The byte array object.
+     * @return The output stream.
+     */
+    friend std::ostream& operator<<(std::ostream& os, const bytearray& byteArray) {
+        os << byteArray.toHex(true);
+        return os;
+    }
+
+    /**
+     * @brief Conversion operator to convert byte array to std::string.
+     *
+     * @note This is provided to support code that relies on byte array
+     *       being representd as a string.
+     * @return String containing the raw bytes of the byte array
+     */
+    operator std::string() const { return std::string(data_.begin(), data_.end()); }
+
+    //! @cond Doxygen_Suppress
+    // Expose vector-like functionality
+    size_t size() const { return data_.size(); }
+    const uint8_t* data() const { return data_.data(); }
+    bool empty() const { return data_.empty(); }
+    void clear() { data_.clear(); }
+    uint8_t& operator[](size_t index) { return data_[index]; }
+    const uint8_t& operator[](size_t index) const { return data_[index]; }
+    void push_back(uint8_t byte) { data_.push_back(byte); }
+    auto begin() const { return data_.begin(); }
+    auto end() const { return data_.end(); }
+    //! @endcond
+
+  private:
+    std::vector<uint8_t> data_;
+};
+
+}  // namespace kvn
+
+#endif  // KVN_BYTEARRAY_H

--- a/src/thirdparty/simplebluez/interfaces/Device1.h
+++ b/src/thirdparty/simplebluez/interfaces/Device1.h
@@ -5,6 +5,8 @@
 
 #include <string>
 
+#include "simplebluez/Types.h"
+
 namespace SimpleBluez {
 
 class Device1 : public SimpleDBus::Interface {
@@ -27,8 +29,8 @@ class Device1 : public SimpleDBus::Interface {
     std::string Alias();
     std::string Name();
     std::vector<std::string> UUIDs();
-    std::map<uint16_t, std::vector<uint8_t>> ManufacturerData(bool refresh = true);
-    std::map<std::string, std::vector<uint8_t>> ServiceData(bool refresh = true);
+    std::map<uint16_t, ByteArray> ManufacturerData(bool refresh = true);
+    std::map<std::string, ByteArray> ServiceData(bool refresh = true);
     bool Paired(bool refresh = true);
     bool Connected(bool refresh = true);
     bool ServicesResolved(bool refresh = true);
@@ -48,8 +50,8 @@ class Device1 : public SimpleDBus::Interface {
     std::string _address_type;
     bool _connected;
     bool _services_resolved;
-    std::map<uint16_t, std::vector<uint8_t>> _manufacturer_data;
-    std::map<std::string, std::vector<uint8_t>> _service_data;
+    std::map<uint16_t, ByteArray> _manufacturer_data;
+    std::map<std::string, ByteArray> _service_data;
 };
 
 }  // namespace SimpleBluez

--- a/src/thirdparty/simpledbus/advanced/Proxy.h
+++ b/src/thirdparty/simpledbus/advanced/Proxy.h
@@ -2,6 +2,7 @@
 
 #include <simpledbus/advanced/Interface.h>
 #include <simpledbus/external/kvn_safe_callback.hpp>
+#include <simpledbus/base/Path.h>
 
 #include <memory>
 #include <mutex>
@@ -59,6 +60,19 @@ class Proxy {
         std::scoped_lock lock(_child_access_mutex);
         for (auto& [path, child] : _children) {
             result.push_back(std::dynamic_pointer_cast<T>(child));
+        }
+        return result;
+    }
+
+    template <typename T>
+    std::vector<std::shared_ptr<T>> children_casted_with_prefix(const std::string& prefix) {
+        std::vector<std::shared_ptr<T>> result;
+        std::scoped_lock lock(_child_access_mutex);
+        for (auto& [path, child] : _children) {
+            const std::string next_child = SimpleDBus::Path::next_child_strip(_path, path);
+            if (next_child.find(prefix) == 0) {
+                result.push_back(std::dynamic_pointer_cast<T>(child));
+            }
         }
         return result;
     }

--- a/src/thirdparty/simpledbus/base/Holder.h
+++ b/src/thirdparty/simpledbus/base/Holder.h
@@ -8,6 +8,28 @@
 
 namespace SimpleDBus {
 
+class ObjectPath {
+  public:
+    ObjectPath(const std::string& path) : path(path) {}
+    ObjectPath(const char* path) : path(path) {}
+    operator std::string() const { return path; }
+    bool operator<(const ObjectPath& other) const { return path < other.path; }
+
+  private:
+    std::string path;
+};
+
+class Signature {
+  public:
+    Signature(const std::string& signature) : signature(signature) {}
+    Signature(const char* signature) : signature(signature) {}
+    operator std::string() const { return signature; }
+    bool operator<(const Signature& other) const { return signature < other.signature; }
+
+  private:
+    std::string signature;
+};
+
 class Holder;
 
 class Holder {
@@ -37,9 +59,10 @@ class Holder {
     } Type;
 
     Type type() const;
-    std::string represent();
-    std::string signature();
+    std::string represent() const;
+    std::string signature() const;
 
+    // TODO: Deprecate these functions in favor of templated version.
     static Holder create_boolean(bool value);
     static Holder create_byte(uint8_t value);
     static Holder create_int16(int16_t value);
@@ -50,12 +73,14 @@ class Holder {
     static Holder create_uint64(uint64_t value);
     static Holder create_double(double value);
     static Holder create_string(const std::string& str);
-    static Holder create_object_path(const std::string& str);
-    static Holder create_signature(const std::string& str);
+    static Holder create_object_path(const ObjectPath& path);
+    static Holder create_signature(const Signature& signature);
     static Holder create_array();
     static Holder create_dict();
 
     std::any get_contents() const;
+
+    // TODO: Deprecate these functions in favor of templated version.
     bool get_boolean() const;
     uint8_t get_byte() const;
     int16_t get_int16() const;
@@ -83,6 +108,16 @@ class Holder {
     void dict_append(Type key_type, std::any key, Holder value);
     void array_append(Holder holder);
 
+    // Template speciallizations.
+    template <typename T>
+    static Holder create();
+
+    template <typename T>
+    static Holder create(T value);
+
+    template <typename T>
+    T get() const;
+
   private:
     Type _type = NONE;
 
@@ -96,15 +131,15 @@ class Holder {
     // Dictionaries are stored within a vector as a tuple of <key_type, key, holder>
     std::vector<std::tuple<Type, std::any, Holder>> holder_dict;
 
-    std::vector<std::string> _represent_container();
-    std::string _represent_simple();
-    std::string _signature_simple();
+    std::vector<std::string> _represent_container() const;
+    std::string _represent_simple() const;
+    std::string _signature_simple() const;
 
     template <typename T>
     std::map<T, Holder> _get_dict(Type key_type) const;
 
-    static std::string _signature_type(Type type);
-    static std::string _represent_type(Type type, std::any value);
+    static std::string _signature_type(Type type) noexcept;
+    static std::string _represent_type(Type type, std::any value) noexcept;
 };
 
 }  // namespace SimpleDBus

--- a/src/thirdparty/simpledbus/base/Message.h
+++ b/src/thirdparty/simpledbus/base/Message.h
@@ -1,76 +1,73 @@
 #pragma once
 
 #include <dbus/dbus.h>
-
 #include <atomic>
-#include <stack>
 #include <string>
 #include <vector>
-
-#include "Connection.h"
 #include "Holder.h"
 
 namespace SimpleDBus {
 
-class Connection;
-class Interface;
-
 class Message {
   public:
-    typedef enum {
+    enum class Type {
         INVALID = DBUS_MESSAGE_TYPE_INVALID,
         METHOD_CALL = DBUS_MESSAGE_TYPE_METHOD_CALL,
         METHOD_RETURN = DBUS_MESSAGE_TYPE_METHOD_RETURN,
         ERROR = DBUS_MESSAGE_TYPE_ERROR,
         SIGNAL = DBUS_MESSAGE_TYPE_SIGNAL,
-    } Type;
+    };
+
+    static constexpr int INVALID_UNIQUE_ID = -1;
 
     Message();
-    Message(DBusMessage* msg);
-    Message(Message&& other);                  // Custom move constructor
-    Message(const Message& other);             // Custom copy constructor
-    Message& operator=(Message&& other);       // Custom move assignment
-    Message& operator=(const Message& other);  // Custom copy assignment
+    Message(Message&& other) noexcept;
+    Message(const Message& other);
+    Message& operator=(Message&& other) noexcept;
+    Message& operator=(const Message& other);
     ~Message();
 
-    bool is_valid() const;
-    void append_argument(Holder argument, std::string signature);
+    operator DBusMessage*() const;
 
+    bool is_valid() const;
+    void append_argument(const Holder& argument, const std::string& signature);
     Holder extract();
     void extract_reset();
     bool extract_has_next();
     void extract_next();
     std::string to_string(bool append_arguments = false) const;
 
-    int32_t get_unique_id();
-    uint32_t get_serial();
+    uint32_t get_ref_count() const;
+    int32_t get_unique_id() const;
+    uint32_t get_serial() const;
     std::string get_signature();
-    std::string get_interface();
-    std::string get_path();
-    std::string get_member();
+    std::string get_interface() const;
+    std::string get_path() const;
+    std::string get_member() const;
     Type get_type() const;
 
-    bool is_signal(std::string interface, std::string signal_name);
+    bool is_signal(const std::string& interface, const std::string& signal_name) const;
+    bool is_method_call(const std::string& interface, const std::string& method) const;
 
-    static Message create_method_call(std::string bus_name, std::string path, std::string interface,
-                                      std::string method);
-
+    static Message from_retained(DBusMessage* msg);
+    static Message from_acquired(DBusMessage* msg);
+    static Message create_method_call(const std::string& bus_name, const std::string& path,
+                                      const std::string& interface, const std::string& method);
     static Message create_method_return(const Message& msg);
-
-    static Message create_error(const Message& msg, std::string error_name, std::string error_message);
+    static Message create_error(const Message& msg, const std::string& error_name, const std::string& error_message);
+    static Message create_signal(const std::string& path, const std::string& interface, const std::string& signal);
 
   private:
-    friend class Connection;
+    static std::atomic_int32_t _creation_counter;
 
-    static std::atomic_int32_t creation_counter;
-    int indent;
-
-    int _unique_id;
+    int _indent = 0;
+    int32_t _unique_id = INVALID_UNIQUE_ID;
     DBusMessageIter _iter;
-    bool _iter_initialized;
-    bool _is_extracted;
+    bool _iter_initialized = false;
+    bool _is_extracted = false;
     Holder _extracted;
-    DBusMessage* _msg;
+    DBusMessage* _msg = nullptr;
+    std::vector<Holder> _arguments;
 
     Holder _extract_bytearray(DBusMessageIter* iter);
     Holder _extract_array(DBusMessageIter* iter);
@@ -83,12 +80,10 @@ class Message {
      * @param argument  Argument to append.
      * @param signature Signature of the argument.
      */
-    void _append_argument(DBusMessageIter* iter, Holder& argument, std::string signature);
+    void _append_argument(DBusMessageIter* iter, const Holder& argument, const std::string& signature);
 
     void _invalidate();
     void _safe_delete();
-
-    std::vector<Holder> _arguments;
 };
 
 }  // namespace SimpleDBus

--- a/src/thirdparty/simpledbus/base/Path.h
+++ b/src/thirdparty/simpledbus/base/Path.h
@@ -18,6 +18,7 @@ class Path {
     static bool is_parent(const std::string& base, const std::string& path);
 
     static std::string next_child(const std::string& base, const std::string& path);
+    static std::string next_child_strip(const std::string& base, const std::string& path);
 };
 
 }  // namespace SimpleDBus


### PR DESCRIPTION
Fixes #2 

I tested on nixos with the updated [SimpleBluez 0.8.1 merged](https://github.com/sefodopo/nixpkgs/tree/test_zmkBATx_pr_SimpleBluez_0.8.1) (which is what NixOS/Nixpkgs#354266 is trying to do) and it now builds and appears to function correctly.

It looks like there might be a better way to convert the `ByteArray`s now with the new version. But this is the simplest fix that I could find without changing a bunch of code.